### PR TITLE
Add lint to the build process and allow more commit types to trigger the release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ cache:
   directories:
     - node_modules
 
+before_script:
+  - npm run lint
+
 stages:
   - name: test
   - name: release

--- a/package.json
+++ b/package.json
@@ -58,5 +58,18 @@
     "umd/",
     "cjs/",
     "esm/"
-  ]
+  ],
+  "release": {
+    "analyzeCommits": {
+      "preset": "angular",
+      "releaseRules": [
+        {"type": "docs", "scope":"README", "release": "patch"},
+        {"type": "refactor", "release": "patch"},
+        {"type": "style", "release": "patch"}
+      ],
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "MAJOR VERSION CHANGE"]
+      }
+    }
+  }
 }


### PR DESCRIPTION
A few notes:
* The build should fail if eslint is not happy with the code. That's it.
* I want a more swift release cycle to publish any improvement sooner. Therefore on top of "fix", "feat" and "perf", the following types should now trigger the release:
  * docs(README) - patch
  * refactor - patch
  * style - patch