### PR TITLE
Fix travis deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ stages:
 jobs:
   include:
     - stage: release
-      node_js: lts/*
-      script: skip
+      node_js: 8
       deploy:
         provider: script
         skip_cleanup: true


### PR DESCRIPTION
Looks like the build was not happening with `script: skip`. 